### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Use a smaller base image for Python 3.12
-FROM python:3.12-slim AS base
+# FROM python:3.12-slim AS base
+FROM --platform=linux/arm64 python:3.12-slim AS base
 
 # Metadata about the image
 LABEL authors="WasinUddy"


### PR DESCRIPTION
suggesting to change python to reference arm architecture. Tried running this docker container in oracle cloud, using ampere compute (arm) and receive the following error "exec /usr/local/bin/python: exec format error". This thread )https://stackoverflow.com/questions/74884770/python-exec-usr-local-bin-python3-exec-format-error-on-docker-while-using-ap) suggested the docker container needs to reference arm architecture rather than x86.