### PR TITLE
Persisting settings changes back to host config files

### DIFF
--- a/backend/minecraft_server.py
+++ b/backend/minecraft_server.py
@@ -76,6 +76,10 @@ class MinecraftServer:
         force_shutdown (bool): Forcefully shutdown the server instance if True.
         """
         if self.instance:
+            # Sync config files from game instance directory to mapped volume
+            for config_file in self.config_files:
+                shutil.copy(f'./instance/{config_file}', f'./configs/{config_file}')
+
             if not force_shutdown:
                 self.instance.stdin.write('stop\n')
                 self.instance.stdin.flush()


### PR DESCRIPTION
I noticed that if I made changes to the config in-game, or even from the web-console, such as 'op someUser' or 'allowlist add user', the changes would be lost when the container was restarted.  

This change takes the changes and copies them back to the config files that are on the host system.

This fixes #27 