### PR TITLE
fix: migrate pre-v3 world permissions safely on startup

### DIFF
--- a/.github/workflows/build-montainer-stable-image.yaml
+++ b/.github/workflows/build-montainer-stable-image.yaml
@@ -10,7 +10,7 @@ on:
       - 'acceptance/**'
       - 'test/**'
       - 'examples/docker/**'
-      - 'scripts/download_minecraft_server.py'
+      - 'scripts/**'
       - 'go.mod'
       - 'go.sum'
       - 'Dockerfile'
@@ -151,7 +151,7 @@ jobs:
                     versions/preview.*)
                       preview=true
                       ;;
-                    cmd/*|internal/*|frontend/*|acceptance/*|test/*|examples/docker/*|scripts/download_minecraft_server.py|go.mod|go.sum|Dockerfile|.dockerignore|.github/scripts/validate_image_tag_contract.py|.github/workflows/ci.yaml|.github/workflows/build-test-promote-image.yaml|.github/workflows/promote-tested-image.yaml|.github/workflows/build-montainer-stable-image.yaml|.github/workflows/build-montainer-preview-image.yaml)
+                    cmd/*|internal/*|frontend/*|acceptance/*|test/*|examples/docker/*|scripts/*|go.mod|go.sum|Dockerfile|.dockerignore|.github/scripts/validate_image_tag_contract.py|.github/workflows/ci.yaml|.github/workflows/build-test-promote-image.yaml|.github/workflows/promote-tested-image.yaml|.github/workflows/build-montainer-stable-image.yaml|.github/workflows/build-montainer-preview-image.yaml)
                       stable=true
                       preview=true
                       ;;
@@ -203,7 +203,7 @@ jobs:
     with:
       server_type: stable
       version_file: versions/stable.txt
-      acceptance_suites: '["smoke", "lifecycle", "otel-export", "otel-outage", "otel-flush", "backup", "client"]'
+      acceptance_suites: '["smoke", "lifecycle", "otel-export", "otel-outage", "otel-flush", "backup", "client", "upgrade"]'
 
   preview-image:
     name: Preview track

--- a/.github/workflows/build-test-promote-image.yaml
+++ b/.github/workflows/build-test-promote-image.yaml
@@ -196,3 +196,7 @@ jobs:
           for network in "${networks[@]}"; do
             docker network rm "$network" || true
           done
+          mapfile -t volumes < <(docker volume ls -q --filter 'label=io.montainer.acceptance=real-image')
+          if [ "${#volumes[@]}" -gt 0 ]; then
+            docker volume rm --force "${volumes[@]}"
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,7 @@ jobs:
               'otel-flush',
               'backup',
               'client',
+              'upgrade',
             ];
             const failedOrMissingSuites = requiredSuites.filter((suite) => {
               const job = latestJobEndingWith(`3 · Accept / stable / ${suite}`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.0.2] - 2026-07-20
+### Fixed
+- On every Docker start, safely migrate and recursively validate pre-v3 instance and persistence data without following symlinked paths or crossing nested mounts, then drop all privileges and run Montainer, Bedrock, and the health probe as UID/GID `10001`.
+- Support both the default migration bootstrap and an explicitly non-root, runtime-hardened deployment without breaking container health checks.
+- Expose the writable Bedrock library path only after the bootstrap has dropped to UID/GID `10001`, preventing root health or migration tools from loading instance-controlled libraries.
+- Gate stable promotion on upgrading and joining a real world made by the digest-pinned pre-v3 image, preserving logical scoreboard state, restoring the uploaded backup into fresh volumes where the same state must load, migrating a custom instance root, pruning nested mounts literally, and keeping explicit non-root container health functional.
+
 ## [3.0.1] - 2026-07-16
 ### Fixed
 - Publish stable and preview images under the exact Minecraft Bedrock version (for example, `1.26.33.2`) instead of a version/commit composite tag.

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,8 @@ RUN mkdir -p /app/instance/worlds /app/configs /app/resource_packs /app/logs /ap
 COPY --from=bedrock --chown=montainer:montainer /out/ /app/instance/
 COPY --from=frontend --chown=montainer:montainer /src/web/dist/ /app/dist/
 COPY --from=go-builder --chown=montainer:montainer /out/montainer /app/montainer
+COPY --chown=root:root scripts/docker-entrypoint.sh /usr/local/bin/montainer-entrypoint
+RUN chmod 0755 /usr/local/bin/montainer-entrypoint
 
 ENV LISTEN_ADDR=:8000 \
     GIN_MODE=release \
@@ -75,15 +77,16 @@ ENV LISTEN_ADDR=:8000 \
     CONFIG_DIR=/app/configs \
     RESOURCE_PACKS_DIR=/app/resource_packs \
     LOG_DIR=/app/logs \
-    STATIC_DIR=/app/dist \
-    LD_LIBRARY_PATH=/app/instance
+    STATIC_DIR=/app/dist
 
-USER montainer
+# The entrypoint repairs pre-v3 root-owned mounts, drops every capability, and
+# execs Montainer as UID/GID 10001 before the application or Bedrock starts.
+USER root
 
 EXPOSE 8000 19132/udp 19133/udp
 VOLUME ["/app/instance/worlds", "/app/configs", "/app/resource_packs", "/app/logs"]
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-    CMD curl --fail --silent --show-error http://127.0.0.1:8000/healthz || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5m --retries=3 \
+    CMD ["/usr/local/bin/montainer-entrypoint", "__healthcheck"]
 
-ENTRYPOINT ["/app/montainer"]
+ENTRYPOINT ["/usr/local/bin/montainer-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ docker compose \
 
 The example Collector uses its debug exporter. Replace that exporter with OTLP, Loki, or a vendor exporter for production. Minecraft logs can contain player names, IP addresses, chat, and commands, so protect the telemetry destination accordingly.
 
-Only `http/protobuf` log export is supported in v2. `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` is used exactly as supplied; the generic `OTEL_EXPORTER_OTLP_ENDPOINT` receives `/v1/logs` automatically.
+Only `http/protobuf` log export is currently supported. `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` is used exactly as supplied; the generic `OTEL_EXPORTER_OTLP_ENDPOINT` receives `/v1/logs` automatically.
 
 ## Persistent data and container permissions
 
@@ -146,7 +146,88 @@ Only `http/protobuf` log export is supported in v2. `OTEL_EXPORTER_OTLP_LOGS_END
 
 Before each start, persistent configuration is copied into the Bedrock instance. On first run, packaged defaults are copied out to the configuration volume. Configuration is persisted again only after the child process has been reaped.
 
-The image runs as UID/GID `10001`. Docker-managed named volumes work without host preparation. For bind mounts on Linux, create the directories first and make them writable by that identity.
+Montainer and Bedrock run as UID/GID `10001`. The default Docker entrypoint starts as root, makes the configured Bedrock instance and persistence roots belong to that identity, migrates legacy root-owned entries below them, validates every required directory and file, then irrevocably drops its groups and capabilities before it starts Montainer. Mutating scans prune kernel-reported nested mounts, and the validation repeats on every start so a rollback or sidecar cannot leave newly inaccessible LevelDB files hidden behind stale migration state.
+
+Set `MONTAINER_AUTO_CHOWN=false` only when UID/GID `10001` already has the required access: read/write for the instance, worlds, configuration, and logs, and read access for resource packs. The migration rejects symbolic links in configured path components, internal symbolic links outside resource-pack trees, special files, protected system roots, and overlaps between configured roots (apart from the required `INSTANCE_DIR/worlds` nesting). Resource-pack symlinks remain supported and are handled without root dereferencing. The scan never changes entries below a nested mount and fails before Bedrock starts if ownership, modes, ACLs, or storage behavior still deny access. Custom `INSTANCE_DIR`, `CONFIG_DIR`, `RESOURCE_PACKS_DIR`, and `LOG_DIR` values are honored; point each at a distinct, dedicated data directory.
+
+The bootstrap requires exclusive access to those mounts. Do not let a sidecar or host process add mounts, replace path components, or rewrite the data tree while the ownership scan is running. For shared-writer storage, stop every writer and perform a one-time storage-side migration, then run with `MONTAINER_AUTO_CHOWN=false`.
+
+The image is configured as root so the entrypoint can repair existing Docker volumes. In the default bootstrap profile, the application, Bedrock child, and health probe all run as UID/GID `10001` with no capabilities and `no_new_privs`. Docker starts ad-hoc `exec` commands from the configured image identity, so use `docker compose exec --user 10001:10001 montainer ...` unless a deliberate recovery operation requires root.
+
+Preserve the image entrypoint. Overriding it with Kubernetes `command`, Compose `entrypoint`, or `docker run --entrypoint /app/montainer` bypasses migration and the root-to-`10001` security boundary. If an override is unavoidable, configure UID/GID `10001`, drop all capabilities, and enable `no-new-privileges` at the container runtime.
+
+An explicitly non-root container skips ownership migration and therefore requires already-accessible storage. Because a non-root process cannot clear its own kernel capability bounding set, also ask the container runtime to drop it; the entrypoint refuses a weaker configuration:
+
+```yaml
+services:
+  montainer:
+    user: "10001:10001"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+```
+
+Kubernetes deployments can keep the container non-root with this security context:
+
+```yaml
+spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+    fsGroupChangePolicy: Always
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: montainer
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+```
+
+This skips the root bootstrap. A CSI driver with volume-group support can make a pre-v3 PVC accessible through `fsGroup`; otherwise use a stopped one-time Job, init container, or storage-layer ACL/ownership change. Some CSI drivers perform the group change themselves and ignore `fsGroupChangePolicy`, so verify the resulting recursive access before starting Bedrock.
+
+To recover a volume before the fixed image is available, first stop Bedrock cleanly and take a raw volume snapshot. The following command targets the supplied Compose stack; for another deployment, run the equivalent command with its normal Compose file and environment options while the Montainer service remains stopped. Run it with the exact original Compose project identity—same directory and any `--project-name`/`COMPOSE_PROJECT_NAME` value—and inspect the resolved mounts first, otherwise Compose can create fresh volumes instead of repairing the server's real data.
+
+```bash
+docker compose \
+  --env-file examples/docker/.env \
+  -f examples/docker/docker-compose.yaml \
+  run --rm --no-deps --user 0:0 --entrypoint sh montainer -ceu '
+  for path in /app/instance /app/instance/worlds /app/configs /app/resource_packs /app/logs; do
+    [ -e "$path" ] || continue
+    mounts=$(findmnt -R -l -n -o TARGET --target "$path")
+    set -- "$path" -xdev
+    while IFS= read -r nested; do
+      case "$nested" in
+        *\\x[0-9A-Fa-f][0-9A-Fa-f]*)
+          printf "refusing escaped or control-character mount target below %s\n" "$path" >&2
+          exit 1
+          ;;
+      esac
+      case "$nested" in
+        "$path") ;;
+        "$path"/*)
+          pattern=$(printf "%s\n" "$nested" | sed "s/[][\\\\*?]/\\\\&/g")
+          set -- "$@" -path "$pattern" -prune -o
+          ;;
+      esac
+    done <<EOF
+$mounts
+EOF
+    set -- "$@" \
+      \( -type d -o \( \( -type f -o -type l \) -links 1 \) \) \
+      \( -uid 0 -o -gid 0 \) \
+      -exec chown --no-dereference 10001:10001 {} +
+    find "$@"
+  done
+'
+```
+
+This repair preserves non-root custom ownership, avoids multiply linked files, and prunes nested mounts. An inaccessible hardlink, a bind-mount root owned by another host UID, or storage that rejects ownership changes needs a deliberate host-side ownership or ACL decision. Do not add `--volumes` to a Compose shutdown command and do not run this while either the old or new Bedrock process is using LevelDB.
 
 Use a container or Kubernetes termination grace period of at least `90s` with the default lifecycle timeouts. If the timeouts are increased, allow at least:
 
@@ -168,6 +249,7 @@ Use a container or Kubernetes termination grace period of at least `90s` with th
 | `CONFIG_DIR` | Persistent configuration directory. | `./configs` (`/app/configs` in Docker) |
 | `RESOURCE_PACKS_DIR` | Persistent resource-pack source. | `./resource_packs` (`/app/resource_packs` in Docker) |
 | `STATIC_DIR` | Built frontend directory. | `./web/dist` (`/app/dist` in Docker) |
+| `MONTAINER_AUTO_CHOWN` | Docker entrypoint migrates legacy root-owned data before dropping privileges. | `true` |
 | `BEDROCK_AUTO_START` | Start Bedrock with Montainer. | `true` |
 | `BEDROCK_SHUTDOWN_TIMEOUT` | Graceful child-process stop timeout. | `15s` |
 | `BEDROCK_LIFECYCLE_TIMEOUT` | Timeout for each pre-start or post-stop filesystem phase. | `15s` |
@@ -280,11 +362,11 @@ GODOG_TAGS='@otel' go test -v -count=1 ./acceptance
 
 See [acceptance/README.md](acceptance/README.md) for binary overrides, temporary-workspace diagnostics, and the covered business behavior.
 
-A separate Docker acceptance suite exercises an already-built image with its packaged Mojang binary. It creates an isolated network and container stack per scenario and covers exact-version startup, RakNet discovery, concurrent lifecycle requests, OTLP export (`@otel-export`), Collector outage isolation (`@otel-outage`), shutdown flushing (`@otel-flush`), concurrent MinIO backups, ZIP integrity, and post-backup gameplay readiness. Stable releases also launch an offline virtual Bedrock player that must spawn, appear in the server player list, and receive a teleport movement packet.
+A separate Docker acceptance suite exercises an already-built image with its packaged Mojang binary. It creates an isolated network and container stack per scenario and covers exact-version startup, RakNet discovery, concurrent lifecycle requests, OTLP export (`@otel-export`), Collector outage isolation (`@otel-outage`), shutdown flushing (`@otel-flush`), concurrent MinIO backups, ZIP integrity, and post-backup gameplay readiness. Its stable-only upgrade shard creates logical scoreboard state with the digest-pinned pre-v3 image, reuses that image's root-owned volumes under the candidate, joins that upgraded world with a virtual player, downloads the S3 backup, restores it externally into fresh named volumes, and queries the same scoreboard state from that restored world. Separate scenarios cover a root-owned custom `INSTANCE_DIR`, literal same-device nested-mount pruning, and the runtime-hardened explicit non-root profile including its Docker health probe. Stable releases also launch an offline virtual Bedrock player that must spawn, appear in the server player list, and receive a teleport movement packet.
 
 ```bash
 GODOG_TAGS='@smoke' \
-MONTAINER_ACCEPTANCE_IMAGE='montainer:v2' \
+MONTAINER_ACCEPTANCE_IMAGE='montainer:local' \
 MONTAINER_EXPECTED_BEDROCK_VERSION="$(cat versions/stable.txt)" \
   go test -v -count=1 ./acceptance/realimage
 ```
@@ -295,19 +377,19 @@ MONTAINER_EXPECTED_BEDROCK_VERSION="$(cat versions/stable.txt)" \
 docker build \
   --build-arg SERVER_TYPE=stable \
   --build-arg BEDROCK_VERSION="$(cat versions/stable.txt)" \
-  -t montainer:v2 .
+  -t montainer:local .
 
 docker build \
   --build-arg SERVER_TYPE=preview \
   --build-arg BEDROCK_VERSION="$(cat versions/preview.txt)" \
-  -t montainer:v2-preview .
+  -t montainer:local-preview .
 ```
 
-The scraper records each channel's version, exact Mojang URL, and archive SHA-256 under `versions/`. The multi-stage build verifies that the URL matches the channel/version and that the downloaded bytes match the pinned checksum before producing the non-root AMD64 Debian runtime.
+The scraper records each channel's version, exact Mojang URL, and archive SHA-256 under `versions/`. The multi-stage build verifies that the URL matches the channel/version and that the downloaded bytes match the pinned checksum before producing the AMD64 Debian image. Its short root bootstrap handles legacy volume ownership; Montainer, Bedrock, and the health probe then run unprivileged.
 
 CI is one connected, numbered DAG. Stage 0 plans the affected release channels while Stage 1 runs a six-row quality matrix: frontend, Go/race/vet/actionlint, and four fake-Bedrock business groups. A main push reuses that matrix once rather than repeating it inside separate stable and preview workflows. Stable-only metadata changes select stable, preview-only metadata changes select preview, and common runtime changes select both. Selective routing is trusted only when the previous commit completed this delivery pipeline successfully; otherwise both channels run.
 
-Stages 2 and 3 build each selected Mojang-backed image once, record a channel-specific archive SHA-256 and image ID, and fan that exact artifact out to seven stable or six preview real-image runners. Every runner verifies both identities before loading the image. Stage 4 gives package-write permission only to the selected channel's promotion job after its matrix succeeds. Stable promotion connects directly to Stage 5, which validates the same-run identity artifact, current Minecraft-version manifest, and recorded digest before considering the latest changelog version for an idempotent GitHub release. All planning, quality, build, and acceptance jobs remain read-only. A common main-branch change now schedules 25 runner jobs including release instead of 36, while PR validation remains six concurrent quality jobs. Manual dispatch can select `stable`, `preview`, or `both`, defaults to validation-only, and may publish only with an explicit opt-in on `main`. Preview keeps the protocol-independent RakNet gate because third-party full-client libraries may temporarily lag Mojang preview protocols.
+Stages 2 and 3 build each selected Mojang-backed image once, record a channel-specific archive SHA-256 and image ID, and fan that exact artifact out to eight stable or six preview real-image runners. Every runner verifies both identities before loading the image. Stable additionally upgrades a real root-owned legacy world and backs it up before promotion. Stage 4 gives package-write permission only to the selected channel's promotion job after its matrix succeeds. Stable promotion connects directly to Stage 5, which validates the same-run identity artifact, current Minecraft-version manifest, and recorded digest before considering the latest changelog version for an idempotent GitHub release. All planning, quality, build, and acceptance jobs remain read-only. A common main-branch change now schedules 26 runner jobs including release instead of 36, while PR validation remains six concurrent quality jobs. Manual dispatch can select `stable`, `preview`, or `both`, defaults to validation-only, and may publish only with an explicit opt-in on `main`. Preview keeps the protocol-independent RakNet gate because third-party full-client libraries may temporarily lag Mojang preview protocols.
 
 ```mermaid
 flowchart LR
@@ -315,7 +397,7 @@ flowchart LR
     P --> PB["2 · Build preview"]
     Q["1 · Quality matrix ×6"] --> SB
     Q --> PB
-    SB --> SA["3 · Stable acceptance ×7"]
+    SB --> SA["3 · Stable acceptance ×8"]
     PB --> PA["3 · Preview acceptance ×6"]
     SA --> SP["4 · Promote stable"]
     PA --> PP["4 · Promote preview"]
@@ -329,14 +411,14 @@ The container image remains the deployment boundary, and the established managem
 - the backend is now a single Go binary rather than Python and Uvicorn;
 - Python runtime dependencies are no longer installed in the image;
 - direct binary runs read process environment variables only; use an explicit launcher or `--env-file` instead of relying on Pydantic `.env` loading;
-- the runtime user is UID/GID `10001`, so Linux bind mounts may need ownership changes;
+- Montainer and Bedrock run as UID/GID `10001`; the Docker entrypoint automatically migrates root-owned files in the Bedrock instance and four documented persistence roots, while explicitly non-root Kubernetes deployments require effective `fsGroup` handling or a one-time volume migration;
 - lifecycle operations are serialized and report explicit states instead of relying only on a boolean;
 - conflicting lifecycle requests now return `409`, an unconfigured backup returns `503`, and timeout/cancellation status mapping is more explicit;
 - HTTP and WebSocket clients are expected to be same-origin; cross-origin consumers should use a correctly configured reverse proxy;
 - logs are rotated and can fan out to OTLP without disabling local access; and
 - the image is explicitly built for `linux/amd64` because the Bedrock binary has no native ARM64 release; each channel publishes the exact Minecraft Bedrock version as its tag (for example, `1.26.33.2`) and overwrites that tag after a newly accepted Montainer rebuild, while release notes provide a digest-pinned reference for immutable deployments.
 
-Back up your existing volumes before upgrading. Reuse the same worlds, configs, and resource-pack mounts, ensure they are writable by UID/GID `10001`, and allow a `90s` termination grace period for the first v2 deployment.
+Stop Bedrock cleanly and take a raw snapshot of existing volumes before upgrading. Reuse the same worlds, configs, resource-pack, and log mounts; the default Docker startup performs the bounded ownership migration automatically. Do not delete, upload, or ask LevelDB to repair a world that still works on a pre-v3 image—the v3.0.1 `Permission denied (13)` failure was an ownership regression, not a world-format migration. Allow a `90s` termination grace period for the first v3 deployment.
 
 ## Contributing
 

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -56,12 +56,15 @@ Available real-image tags are:
 - `@otel-export`: export through the pinned real Collector;
 - `@otel-outage`: unavailable-Collector isolation;
 - `@otel-flush`: graceful-shutdown export flushing;
-- `@backup`: four concurrent saves, MinIO object verification, ZIP integrity, one restart, and gameplay recovery; and
-- `@client`: offline virtual-player spawn, authoritative `list` output, and receipt of a teleport movement packet.
+- `@backup`: four concurrent saves, MinIO object verification, ZIP integrity, one restart, and gameplay recovery;
+- `@client`: offline virtual-player spawn, authoritative `list` output, and receipt of a teleport movement packet; and
+- `@upgrade` (stable only): scenarios covering a genuine root-owned world and scoreboard marker created by the digest-pinned pre-v3 image, a virtual player joining and moving in that upgraded world, external restoration of its downloaded MinIO ZIP into fresh volumes where the same score must load, a root-owned custom `INSTANCE_DIR`, literal same-device nested-mount pruning, and explicit non-root startup with a working unprivileged health probe. Montainer PID 1 and its Bedrock child are checked for UID/GID, capabilities, and `no_new_privs`.
 
 The feature-level `@otel` tag still selects all three OTLP scenarios for a combined local run; CI uses the individual tags so they execute concurrently.
 
-Each scenario owns unique container names, an isolated Docker network, anonymous data volumes, writable non-root configuration, and dynamic host ports. Failed scenarios print Montainer, Collector, MinIO, and virtual-client logs before cleanup.
+`MONTAINER_LEGACY_IMAGE` can override the pinned pre-v3 fixture for local investigation. CI leaves it at the immutable `1.26.33.1` digest so the upgrade contract cannot move with a tag.
+
+Each scenario owns unique container names, an isolated Docker network, isolated persistence, writable non-root configuration, and dynamic host ports. The upgrade shard labels and explicitly removes every legacy, restore-verification, custom-instance, and nested-mount named volume after all containers are gone; other shards use anonymous volumes. Failed scenarios print Montainer, Collector, MinIO, and virtual-client logs before cleanup.
 
 The full client uses a separately pinned gophertunnel module under `test/fixtures/bedrockclient`. It intentionally uses no Microsoft/Xbox credentials and only connects to an isolated server configured with `online-mode=false`. CI makes this a stable-image gate. Preview images always require RakNet discovery but omit the full join when the pinned test client has not yet added Mojang's preview protocol; this avoids mistaking a stale client library for a broken server image.
 
@@ -74,7 +77,7 @@ The connected delivery workflow uses numbered stages and matrices:
 1. `0 · Plan` safely selects stable, preview, or both from the changed paths. It uses a selective delta only after a successful delivery of the previous commit and falls back to both channels otherwise.
 2. `1 · Quality` runs frontend, Go/race/vet/actionlint, and the four fake-Bedrock tag groups as one six-row matrix shared by every selected channel.
 3. `2 · Build` verifies the recorded Mojang URL and SHA-256, builds each selected channel once, and exports a channel-specific Docker archive with a recorded archive SHA-256 and image ID.
-4. `3 · Accept` fans that exact artifact out to seven stable runners (`smoke`, `lifecycle`, the three OTLP tags, `backup`, and `client`) or six preview runners, omitting only the full virtual client.
+4. `3 · Accept` fans that exact artifact out to eight stable runners (`smoke`, `lifecycle`, the three OTLP tags, `backup`, `client`, and `upgrade`) or six preview runners, omitting the full virtual client and legacy-volume upgrade.
 5. `4 · Promote` receives package-write permission only after its channel's acceptance matrix succeeds, reloads the same artifact, overwrites the Minecraft-version tag with that accepted image, copies the same manifest to `latest`, and publishes a channel-specific digest identity record.
 6. `5 · Release` is connected directly to stable promotion. It validates the same-run identity and current version-tag manifest, records a digest-pinned image reference, then creates only an unreleased changelog version; existing tag/release pairs are a clean no-op and interrupted same-commit releases are retryable.
 

--- a/acceptance/realimage/acceptance_test.go
+++ b/acceptance/realimage/acceptance_test.go
@@ -17,6 +17,7 @@ const (
 	expectedVersionEnv    = "MONTAINER_EXPECTED_BEDROCK_VERSION"
 	defaultCollectorImage = "otel/opentelemetry-collector-contrib:0.156.0@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108"
 	defaultMinIOImage     = "minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+	defaultLegacyImage    = "ghcr.io/wasinuddy/montainer-stable:1.26.33.1@sha256:e8cafa80a9ec6cd226eb9ea66f3177fd7925b56bee0bfc75556d8c0c3305f965"
 )
 
 type suiteHarness struct {
@@ -25,6 +26,7 @@ type suiteHarness struct {
 	expectedVersion string
 	collectorImage  string
 	minioImage      string
+	legacyImage     string
 	probeBinary     string
 	clientBinary    string
 	clientRequired  bool
@@ -57,9 +59,10 @@ func TestRealImageAcceptance(t *testing.T) {
 		expectedVersion: expectedVersion,
 		collectorImage:  envOrDefault("MONTAINER_OTEL_COLLECTOR_IMAGE", defaultCollectorImage),
 		minioImage:      envOrDefault("MONTAINER_MINIO_IMAGE", defaultMinIOImage),
+		legacyImage:     envOrDefault("MONTAINER_LEGACY_IMAGE", defaultLegacyImage),
 	}
 	tags := os.Getenv("GODOG_TAGS")
-	harness.clientRequired = tags == "" || strings.Contains(tags, "@client")
+	harness.clientRequired = tags == "" || strings.Contains(tags, "@client") || strings.Contains(tags, "@upgrade")
 	buildDir, err := os.MkdirTemp("", "montainer-real-image-tools-")
 	if err != nil {
 		t.Fatalf("create real-image tool directory: %v", err)
@@ -108,6 +111,7 @@ func (h *suiteHarness) validate() error {
 		"expected Bedrock version": h.expectedVersion,
 		"Collector image":          h.collectorImage,
 		"MinIO image":              h.minioImage,
+		"pre-v3 legacy image":      h.legacyImage,
 		"RakNet probe":             h.probeBinary,
 	} {
 		if strings.TrimSpace(value) == "" {

--- a/acceptance/realimage/docker_test.go
+++ b/acceptance/realimage/docker_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,9 +20,29 @@ import (
 )
 
 const (
-	minioAccessKey = "montainer-access"
-	minioSecretKey = "montainer-secret-acceptance"
+	minioAccessKey         = "montainer-access"
+	minioSecretKey         = "montainer-secret-acceptance"
+	legacyWorldName        = "acceptance-world"
+	legacyObjectiveName    = "legacy_probe"
+	legacyPlayerName       = "LegacyMarker"
+	legacyCanaryName       = "montainer-legacy-canary.txt"
+	legacyCanaryContents   = "Montainer legacy world acceptance canary\n"
+	nestedMountDirectory   = "nested[1]"
+	nestedParentCanary     = "parent-must-migrate.txt"
+	nestedMountCanary      = "nested-must-stay-root.txt"
+	acceptanceVolumeLabel  = "io.montainer.acceptance=real-image"
+	containerInstanceRoot  = "/app/instance"
+	containerWorldsRoot    = containerInstanceRoot + "/worlds"
+	containerCustomRoot    = "/custom-instance"
+	containerConfigsRoot   = "/app/configs"
+	containerResourcesRoot = "/app/resource_packs"
+	containerLogsRoot      = "/app/logs"
 )
+
+type volumeMount struct {
+	name        string
+	destination string
+}
 
 func (s *scenarioState) docker(ctx context.Context, arguments ...string) (string, error) {
 	command := exec.CommandContext(ctx, "docker", arguments...)
@@ -169,21 +191,383 @@ func (s *scenarioState) startMinIO() error {
 	return nil
 }
 
+func (s *scenarioState) seedRootOwnedLegacyWorld() error {
+	if s.candidate != "" {
+		return fmt.Errorf("legacy world must be seeded before the candidate starts")
+	}
+	if len(s.legacyMounts) != 0 {
+		return fmt.Errorf("legacy named volumes have already been created")
+	}
+	if err := s.ensureLegacyImageAvailable(); err != nil {
+		return err
+	}
+
+	s.legacyMounts = []volumeMount{
+		{name: s.networkName + "-worlds", destination: containerWorldsRoot},
+		{name: s.networkName + "-configs", destination: containerConfigsRoot},
+		{name: s.networkName + "-resources", destination: containerResourcesRoot},
+		{name: s.networkName + "-logs", destination: containerLogsRoot},
+	}
+	if err := s.createAcceptanceVolumes(s.legacyMounts); err != nil {
+		return err
+	}
+
+	configVolume, err := s.legacyVolumeFor(containerConfigsRoot)
+	if err != nil {
+		return err
+	}
+	resourceVolume, err := s.legacyVolumeFor(containerResourcesRoot)
+	if err != nil {
+		return err
+	}
+	logVolume, err := s.legacyVolumeFor(containerLogsRoot)
+	if err != nil {
+		return err
+	}
+	helperName := s.trackHelperContainer("legacy-config-seed")
+	if _, err := s.dockerWithin(
+		60*time.Second,
+		"run", "--name", helperName,
+		"--platform", "linux/amd64",
+		"--user", "0:0",
+		"--entrypoint", "/bin/sh",
+		"--volume", configVolume+":"+containerConfigsRoot,
+		"--volume", resourceVolume+":"+containerResourcesRoot,
+		"--volume", logVolume+":"+containerLogsRoot,
+		"--volume", s.configDir+":/tmp/montainer-config-fixtures:ro",
+		s.suite.legacyImage,
+		"-ceu",
+		`for file in server.properties allowlist.json permissions.json; do
+			cp "/tmp/montainer-config-fixtures/$file" "/app/configs/$file"
+			chown 0:0 "/app/configs/$file"
+		done
+		printf 'legacy resource pack fixture\n' > /app/resource_packs/legacy-pack.txt
+		printf 'legacy log fixture\n' > /app/logs/legacy.log
+		chown 0:0 /app/resource_packs/legacy-pack.txt /app/logs/legacy.log`,
+	); err != nil {
+		return fmt.Errorf("seed root-owned legacy configuration: %w", err)
+	}
+
+	legacyName := strings.Replace(s.networkName, "montainer-real-", "montainer-legacy-", 1)
+	if err := s.startCandidateContainer(legacyName, s.suite.legacyImage); err != nil {
+		return err
+	}
+	if err := s.apiEventuallyHealthy(); err != nil {
+		return fmt.Errorf("wait for pre-v3 Montainer API: %w", err)
+	}
+	if err := s.rakNetEventuallyResponds(); err != nil {
+		return fmt.Errorf("discover pre-v3 Bedrock server: %w", err)
+	}
+	legacyUID, err := s.dockerWithin(10*time.Second, "exec", s.candidate, "id", "-u")
+	if err != nil {
+		return fmt.Errorf("inspect pre-v3 runtime identity: %w", err)
+	}
+	if legacyUID != "0" {
+		return fmt.Errorf("pre-v3 runtime UID is %s, want 0", legacyUID)
+	}
+	for _, command := range []string{
+		"scoreboard objectives add " + legacyObjectiveName + " dummy LegacyUpgradeProbe",
+		fmt.Sprintf("scoreboard players set %s %s %d", legacyPlayerName, legacyObjectiveName, s.legacyScore),
+		fmt.Sprintf("scoreboard players test %s %s %d %d", legacyPlayerName, legacyObjectiveName, s.legacyScore, s.legacyScore),
+	} {
+		if err := s.sendCommand(command); err != nil {
+			return fmt.Errorf("seed pre-v3 scoreboard state with %q: %w", command, err)
+		}
+	}
+	if err := s.logsEventuallyContain(legacyScoreSentence(s.legacyScore, s.legacyScore)); err != nil {
+		return fmt.Errorf("verify pre-v3 scoreboard state: %w", err)
+	}
+	if err := s.stopLegacyServerAndContainer(); err != nil {
+		return err
+	}
+	if err := s.createLegacyCanaryAndVerifyRootOwnership(); err != nil {
+		return err
+	}
+
+	// The next candidate must reuse these volumes through the image's normal
+	// entrypoint so the upgrade path, rather than the seeding process, owns the
+	// migration from root to the unprivileged runtime identity.
+	s.candidate = ""
+	s.baseURL = ""
+	s.udpAddress = ""
+	return nil
+}
+
+func (s *scenarioState) rootOwnedCustomInstanceExists() error {
+	if s.candidate != "" {
+		return fmt.Errorf("custom instance must be prepared before the candidate starts")
+	}
+	if len(s.legacyMounts) != 0 {
+		return fmt.Errorf("custom instance volumes have already been created")
+	}
+	if err := s.ensureLegacyImageAvailable(); err != nil {
+		return err
+	}
+
+	s.legacyMounts = []volumeMount{
+		{name: s.networkName + "-custom-instance", destination: containerCustomRoot},
+		{name: s.networkName + "-custom-configs", destination: containerConfigsRoot},
+		{name: s.networkName + "-custom-resources", destination: containerResourcesRoot},
+		{name: s.networkName + "-custom-logs", destination: containerLogsRoot},
+	}
+	if err := s.createAcceptanceVolumes(s.legacyMounts); err != nil {
+		return err
+	}
+
+	arguments := []string{
+		"run", "--name", s.trackHelperContainer("custom-instance-seed"),
+		"--platform", "linux/amd64",
+		"--user", "0:0",
+		"--entrypoint", "/bin/sh",
+	}
+	for _, mount := range s.legacyMounts {
+		arguments = append(arguments, "--volume", mount.name+":"+mount.destination)
+	}
+	arguments = append(
+		arguments,
+		"--volume", s.configDir+":/tmp/montainer-config-fixtures:ro",
+		s.suite.legacyImage,
+		"-ceu",
+		`cp -a /app/instance/. "$1/"
+		for file in server.properties allowlist.json permissions.json; do
+			cp "/tmp/montainer-config-fixtures/$file" "$2/$file"
+		done
+		printf 'legacy custom resource fixture\n' > "$3/legacy-custom-pack.txt"
+		printf 'legacy custom log fixture\n' > "$4/legacy-custom.log"
+		chown -R 0:0 "$1" "$2" "$3" "$4"`,
+		"sh",
+		containerCustomRoot,
+		containerConfigsRoot,
+		containerResourcesRoot,
+		containerLogsRoot,
+	)
+	if _, err := s.dockerWithin(2*time.Minute, arguments...); err != nil {
+		return fmt.Errorf("prepare root-owned custom pre-v3 instance: %w", err)
+	}
+
+	s.env["INSTANCE_DIR"] = containerCustomRoot
+	return nil
+}
+
+func (s *scenarioState) accessibleRootOwnedNestedMountExists() error {
+	if s.candidate != "" {
+		return fmt.Errorf("nested mount must be prepared before the candidate starts")
+	}
+	if len(s.legacyMounts) != 0 {
+		return fmt.Errorf("nested-mount volumes have already been created")
+	}
+	nestedDestination := containerWorldsRoot + "/" + nestedMountDirectory
+	s.legacyMounts = []volumeMount{
+		{name: s.networkName + "-nested-parent", destination: containerWorldsRoot},
+		{name: s.networkName + "-nested-child", destination: nestedDestination},
+		{name: s.networkName + "-nested-configs", destination: containerConfigsRoot},
+		{name: s.networkName + "-nested-resources", destination: containerResourcesRoot},
+		{name: s.networkName + "-nested-logs", destination: containerLogsRoot},
+	}
+	if err := s.createAcceptanceVolumes(s.legacyMounts); err != nil {
+		return err
+	}
+
+	arguments := []string{
+		"run", "--name", s.trackHelperContainer("nested-mount-seed"),
+		"--platform", "linux/amd64",
+		"--user", "0:0",
+		"--entrypoint", "/bin/sh",
+	}
+	for _, mount := range s.legacyMounts {
+		arguments = append(arguments, "--volume", mount.name+":"+mount.destination)
+	}
+	arguments = append(
+		arguments,
+		s.suite.image,
+		"-ceu",
+		`printf 'parent\n' > "$1/$3"
+		printf 'nested\n' > "$2/$4"
+		chown -R 0:0 "$1" "$2" "$5" "$6" "$7"
+		chmod 0777 "$2"
+		chmod 0666 "$2/$4"`,
+		"sh",
+		containerWorldsRoot,
+		nestedDestination,
+		nestedParentCanary,
+		nestedMountCanary,
+		containerConfigsRoot,
+		containerResourcesRoot,
+		containerLogsRoot,
+	)
+	if _, err := s.dockerWithin(60*time.Second, arguments...); err != nil {
+		return fmt.Errorf("prepare accessible root-owned nested mount: %w", err)
+	}
+	s.env["BEDROCK_AUTO_START"] = "false"
+	return nil
+}
+
+func (s *scenarioState) createAcceptanceVolumes(mounts []volumeMount) error {
+	for _, mount := range mounts {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_, err := s.docker(
+			ctx,
+			"volume", "create",
+			"--label", acceptanceVolumeLabel,
+			"--label", "io.montainer.acceptance.network="+s.networkName,
+			mount.name,
+		)
+		cancel()
+		if err != nil {
+			return err
+		}
+		s.volumes = append(s.volumes, mount.name)
+	}
+	return nil
+}
+
+func (s *scenarioState) trackHelperContainer(role string) string {
+	suffix := strings.TrimPrefix(s.networkName, "montainer-real-")
+	name := "montainer-" + role + "-" + suffix
+	s.containers = append(s.containers, name)
+	return name
+}
+
+func (s *scenarioState) ensureLegacyImageAvailable() error {
+	if _, err := s.dockerWithin(30*time.Second, "image", "inspect", s.suite.legacyImage); err == nil {
+		return nil
+	}
+	if _, err := s.dockerWithin(5*time.Minute, "pull", "--platform", "linux/amd64", s.suite.legacyImage); err != nil {
+		return fmt.Errorf("pull digest-pinned pre-v3 fixture: %w", err)
+	}
+	return nil
+}
+
+func (s *scenarioState) legacyVolumeFor(destination string) (string, error) {
+	for _, mount := range s.legacyMounts {
+		if mount.destination == destination {
+			return mount.name, nil
+		}
+	}
+	return "", fmt.Errorf("legacy volume for %s is not configured", destination)
+}
+
+func (s *scenarioState) stopLegacyServerAndContainer() error {
+	status, body, err := s.httpRequest(http.MethodPost, "/stop", nil)
+	if err != nil {
+		return fmt.Errorf("stop pre-v3 Bedrock server: %w", err)
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("pre-v3 stop endpoint returned %d: %s", status, body)
+	}
+	if err := eventually("pre-v3 Bedrock process to stop", 60*time.Second, func() error {
+		_, err := s.dockerWithin(
+			5*time.Second,
+			"exec", s.candidate,
+			"/bin/sh", "-ceu",
+			`for status in /proc/[0-9]*/status; do
+				[ -r "$status" ] || continue
+				[ "$(awk '$1 == "Name:" { print $2 }' "$status")" != bedrock_server ] ||
+					[ "$(awk '$1 == "State:" { print $2 }' "$status")" = Z ] || exit 1
+			done`,
+		)
+		return err
+	}); err != nil {
+		return err
+	}
+	if err := s.stopCandidate(); err != nil {
+		return fmt.Errorf("stop pre-v3 container: %w", err)
+	}
+	if err := s.candidateExitedCleanly(); err != nil {
+		return fmt.Errorf("pre-v3 container did not exit cleanly: %w", err)
+	}
+	return nil
+}
+
+func (s *scenarioState) createLegacyCanaryAndVerifyRootOwnership() error {
+	arguments := []string{
+		"run", "--name", s.trackHelperContainer("legacy-volume-inspect"),
+		"--platform", "linux/amd64",
+		"--user", "0:0",
+		"--entrypoint", "/bin/sh",
+	}
+	for _, mount := range s.legacyMounts {
+		arguments = append(arguments, "--volume", mount.name+":"+mount.destination)
+	}
+	arguments = append(
+		arguments,
+		s.suite.image,
+		"-ceu",
+		`world=$1
+		canary="$world/$2"
+		test -s "$world/level.dat"
+		database_file=$(find "$world/db" -type f -size +0c -print -quit)
+		test -n "$database_file"
+		printf '%s' "$3" > "$canary"
+		chown 0:0 "$canary"
+		for root in "$4" "$5" "$6" "$7"; do
+			unexpected=$(find "$root" -xdev \( -type d -o -type f -o -type l \) \( ! -uid 0 -o ! -gid 0 \) -print -quit)
+			test -z "$unexpected" || {
+				printf 'non-root legacy entry: %s\n' "$unexpected" >&2
+				exit 1
+			}
+		done`,
+		"sh",
+		containerWorldsRoot+"/"+legacyWorldName,
+		legacyCanaryName,
+		legacyCanaryContents,
+		containerWorldsRoot,
+		containerConfigsRoot,
+		containerResourcesRoot,
+		containerLogsRoot,
+	)
+	if _, err := s.dockerWithin(60*time.Second, arguments...); err != nil {
+		return fmt.Errorf("verify genuine root-owned pre-v3 persistence: %w", err)
+	}
+	return nil
+}
+
+func legacyScoreSentence(lower, upper int) string {
+	return fmt.Sprintf("Score %d is in range %d to %d", lower, lower, upper)
+}
+
 func (s *scenarioState) startCandidate() error {
 	if s.candidate != "" {
 		return fmt.Errorf("candidate container has already started")
 	}
 	name := strings.Replace(s.networkName, "montainer-real-", "montainer-app-", 1)
+	return s.startCandidateContainer(name, s.suite.image)
+}
+
+func (s *scenarioState) configureExplicitNonRootCandidate() error {
+	if s.candidate != "" {
+		return fmt.Errorf("explicit non-root mode must be configured before the candidate starts")
+	}
+	s.explicitNonRoot = true
+	return nil
+}
+
+func (s *scenarioState) startCandidateContainer(name, image string) error {
 	s.candidate = name
 	s.containers = append(s.containers, name)
 	arguments := []string{
 		"run", "--detach",
+		"--platform", "linux/amd64",
 		"--name", name,
 		"--network", s.networkName,
 		"--add-host", "host.docker.internal:host-gateway",
 		"--publish", "127.0.0.1::8000/tcp",
 		"--publish", "127.0.0.1::19132/udp",
-		"--volume", s.configDir + ":/app/configs",
+	}
+	if s.explicitNonRoot {
+		arguments = append(
+			arguments,
+			"--user", "10001:10001",
+			"--cap-drop", "ALL",
+			"--security-opt", "no-new-privileges:true",
+		)
+	}
+	if len(s.legacyMounts) == 0 {
+		arguments = append(arguments, "--volume", s.configDir+":"+containerConfigsRoot)
+	} else {
+		for _, mount := range s.legacyMounts {
+			arguments = append(arguments, "--volume", mount.name+":"+mount.destination)
+		}
 	}
 	keys := make([]string, 0, len(s.env))
 	for key := range s.env {
@@ -193,7 +577,7 @@ func (s *scenarioState) startCandidate() error {
 	for _, key := range keys {
 		arguments = append(arguments, "--env", key+"="+s.env[key])
 	}
-	arguments = append(arguments, s.suite.image)
+	arguments = append(arguments, image)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
@@ -211,6 +595,306 @@ func (s *scenarioState) startCandidate() error {
 	s.baseURL = "http://" + httpAddress
 	s.udpAddress = udpAddress
 	return nil
+}
+
+func (s *scenarioState) restoreUploadedBackupIntoFreshNamedVolumes() error {
+	archive, err := s.downloadedBackupBytes()
+	if err != nil {
+		return err
+	}
+	archivePath := filepath.Join(s.tmpDir, "legacy-backup.zip")
+	if err := os.WriteFile(archivePath, archive, 0o600); err != nil {
+		return fmt.Errorf("write downloaded backup for restore: %w", err)
+	}
+
+	if err := s.stopCandidate(); err != nil {
+		return fmt.Errorf("stop upgraded candidate before restore verification: %w", err)
+	}
+	if err := s.candidateExitedCleanly(); err != nil {
+		return fmt.Errorf("upgraded candidate did not exit cleanly before restore verification: %w", err)
+	}
+
+	restoredMounts := []volumeMount{
+		{name: s.networkName + "-restore-worlds", destination: containerWorldsRoot},
+		{name: s.networkName + "-restore-configs", destination: containerConfigsRoot},
+		{name: s.networkName + "-restore-resources", destination: containerResourcesRoot},
+		{name: s.networkName + "-restore-logs", destination: containerLogsRoot},
+	}
+	if err := s.createAcceptanceVolumes(restoredMounts); err != nil {
+		return err
+	}
+
+	worldVolume := ""
+	configVolume := ""
+	for _, mount := range restoredMounts {
+		switch mount.destination {
+		case containerWorldsRoot:
+			worldVolume = mount.name
+		case containerConfigsRoot:
+			configVolume = mount.name
+		}
+	}
+	if worldVolume == "" || configVolume == "" {
+		return fmt.Errorf("restored world and configuration volumes were not configured")
+	}
+
+	const restoreScript = `
+import pathlib
+import shutil
+import stat
+import sys
+import zipfile
+
+archive_path, worlds_root, configs_root = sys.argv[1:]
+config_names = {"server.properties", "allowlist.json", "permissions.json"}
+
+with zipfile.ZipFile(archive_path) as archive:
+    for info in archive.infolist():
+        source_path = pathlib.PurePosixPath(info.filename)
+        if source_path.is_absolute() or ".." in source_path.parts:
+            raise RuntimeError(f"unsafe backup path: {info.filename!r}")
+        file_type = (info.external_attr >> 16) & 0o170000
+        if file_type == stat.S_IFLNK:
+            raise RuntimeError(f"refusing backup symlink: {info.filename!r}")
+
+        destination = None
+        if len(source_path.parts) > 1 and source_path.parts[0] == "worlds":
+            destination = pathlib.Path(worlds_root).joinpath(*source_path.parts[1:])
+        elif len(source_path.parts) == 1 and source_path.name in config_names:
+            destination = pathlib.Path(configs_root, source_path.name)
+        if destination is None:
+            continue
+
+        if info.is_dir():
+            destination.mkdir(parents=True, exist_ok=True)
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with archive.open(info) as source, destination.open("wb") as target:
+            shutil.copyfileobj(source, target)
+`
+	if _, err := s.dockerWithin(
+		2*time.Minute,
+		"run", "--name", s.trackHelperContainer("backup-restore-extract"),
+		"--platform", "linux/amd64",
+		"--user", "0:0",
+		"--entrypoint", "/usr/local/bin/python",
+		"--volume", archivePath+":/tmp/montainer-backup.zip:ro",
+		"--volume", worldVolume+":"+containerWorldsRoot,
+		"--volume", configVolume+":"+containerConfigsRoot,
+		s.suite.legacyImage,
+		"-c", restoreScript,
+		"/tmp/montainer-backup.zip",
+		containerWorldsRoot,
+		containerConfigsRoot,
+	); err != nil {
+		return fmt.Errorf("extract uploaded backup into fresh volumes: %w", err)
+	}
+
+	// Exercise the same ownership migration on the externally restored,
+	// root-owned archive rather than continuing against the original live
+	// volumes. This proves the uploaded LevelDB snapshot itself is usable.
+	s.legacyMounts = restoredMounts
+	s.candidate = ""
+	s.baseURL = ""
+	s.udpAddress = ""
+	restoredName := strings.Replace(s.networkName, "montainer-real-", "montainer-restored-", 1)
+	if err := s.startCandidateContainer(restoredName, s.suite.image); err != nil {
+		return fmt.Errorf("start candidate from restored backup: %w", err)
+	}
+	return nil
+}
+
+func (s *scenarioState) customInstancePersistenceOwnedByMontainer() error {
+	if s.candidate == "" {
+		return fmt.Errorf("candidate container is not running")
+	}
+	return eventually("custom instance persistence to belong to UID/GID 10001", 30*time.Second, func() error {
+		_, err := s.dockerWithin(
+			10*time.Second,
+			"exec", "--user", "10001:10001", s.candidate,
+			"/bin/sh", "-ceu",
+			`test -s "$1/server.properties"
+			test -s "$1/worlds/$5/level.dat"
+			test -f "$2/server.properties"
+			test -f "$3/legacy-custom-pack.txt"
+			test -f "$4/instance.log"
+			for root in "$1" "$2" "$3" "$4"; do
+				unexpected=$(find "$root" -xdev \( -type d -o -type f -o -type l \) \( ! -uid 10001 -o ! -gid 10001 \) -print -quit)
+				test -z "$unexpected" || {
+					printf 'unexpected custom-instance owner: %s\n' "$unexpected" >&2
+					exit 1
+				}
+			done`,
+			"sh",
+			containerCustomRoot,
+			containerConfigsRoot,
+			containerResourcesRoot,
+			containerLogsRoot,
+			legacyWorldName,
+		)
+		return err
+	})
+}
+
+func (s *scenarioState) nestedMountOwnershipIsPreserved() error {
+	if s.candidate == "" {
+		return fmt.Errorf("candidate container is not running")
+	}
+	_, err := s.dockerWithin(
+		10*time.Second,
+		"exec", "--user", "10001:10001", s.candidate,
+		"/bin/sh", "-ceu",
+		`findmnt -n --mountpoint "$2" >/dev/null
+		test "$(stat -c %d "$1")" = "$(stat -c %d "$2")"
+		test "$(stat -c %u:%g "$1")" = 10001:10001
+		test "$(stat -c %u:%g "$1/$3")" = 10001:10001
+		test "$(stat -c %u:%g "$2")" = 0:0
+		test "$(stat -c %u:%g "$2/$4")" = 0:0`,
+		"sh",
+		containerWorldsRoot,
+		containerWorldsRoot+"/"+nestedMountDirectory,
+		nestedParentCanary,
+		nestedMountCanary,
+	)
+	if err != nil {
+		return fmt.Errorf("verify nested mount was pruned from ownership migration: %w", err)
+	}
+	return nil
+}
+
+func (s *scenarioState) candidateContainerEventuallyHealthy() error {
+	if s.candidate == "" {
+		return fmt.Errorf("candidate container is not running")
+	}
+	return eventually("Docker health probe to report healthy", 75*time.Second, func() error {
+		state, err := s.dockerWithin(
+			5*time.Second,
+			"inspect", "--format", "{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}", s.candidate,
+		)
+		if err != nil {
+			return err
+		}
+		if state != "healthy" {
+			return fmt.Errorf("container health is %q", state)
+		}
+		return nil
+	})
+}
+
+func (s *scenarioState) upgradedPersistenceOwnedByMontainer() error {
+	if s.candidate == "" {
+		return fmt.Errorf("candidate container is not running")
+	}
+	return eventually("all upgraded persistence to belong to UID/GID 10001", 30*time.Second, func() error {
+		_, err := s.dockerWithin(
+			10*time.Second,
+			"exec", "--user", "10001:10001", s.candidate,
+			"/bin/sh", "-ceu",
+			`test -s "$1/$5/level.dat"
+			database_file=$(find "$1/$5/db" -type f -size +0c -print -quit)
+			test -n "$database_file"
+			test -f "$1/$5/$6"
+			test -f "$2/server.properties"
+			test -f "$4/instance.log"
+			for root in "$1" "$2" "$3" "$4"; do
+				unexpected=$(find "$root" -xdev \( -type d -o -type f -o -type l \) \( ! -uid 10001 -o ! -gid 10001 \) -print -quit)
+				test -z "$unexpected" || {
+					printf 'unexpected upgraded owner: %s\n' "$unexpected" >&2
+					exit 1
+				}
+			done`,
+			"sh",
+			containerWorldsRoot,
+			containerConfigsRoot,
+			containerResourcesRoot,
+			containerLogsRoot,
+			legacyWorldName,
+			legacyCanaryName,
+		)
+		return err
+	})
+}
+
+func (s *scenarioState) candidateProcessesRunAsMontainer() error {
+	if s.candidate == "" {
+		return fmt.Errorf("candidate container is not running")
+	}
+	configuredEnvironment, err := s.dockerWithin(
+		10*time.Second,
+		"inspect", "--format", "{{range .Config.Env}}{{println .}}{{end}}", s.candidate,
+	)
+	if err != nil {
+		return fmt.Errorf("inspect candidate environment: %w", err)
+	}
+	for _, variable := range strings.Split(configuredEnvironment, "\n") {
+		if strings.HasPrefix(variable, "LD_LIBRARY_PATH=") {
+			return fmt.Errorf("LD_LIBRARY_PATH must not be present in the root container environment")
+		}
+	}
+	expectedLibraryPath := containerInstanceRoot
+	if configured := strings.TrimSpace(s.env["INSTANCE_DIR"]); configured != "" {
+		expectedLibraryPath = configured
+	}
+	return eventually("Montainer and Bedrock to run as UID/GID 10001", 30*time.Second, func() error {
+		status, err := s.currentStatus()
+		if err != nil {
+			return err
+		}
+		if status.PID <= 1 {
+			return fmt.Errorf("Bedrock PID is %d", status.PID)
+		}
+		checks := []struct {
+			pid  int
+			name string
+		}{
+			{pid: 1, name: "montainer"},
+			{pid: status.PID, name: "bedrock_server"},
+		}
+		for _, check := range checks {
+			securityState, err := s.dockerWithin(
+				10*time.Second,
+				"exec", "--user", "10001:10001", s.candidate,
+				"/bin/sh", "-ceu",
+				`status="/proc/$1/status"
+					test -r "$status"
+					test "$(cat "/proc/$1/comm")" = "$2"
+					tr '\000' '\n' < "/proc/$1/environ" | grep -Fqx "LD_LIBRARY_PATH=$3"
+					awk '
+					$1 == "Uid:" {
+						uid_seen=1
+						for (i=2; i<=5; i++) if ($i != 10001) exit 1
+					}
+					$1 == "Gid:" {
+						gid_seen=1
+						for (i=2; i<=5; i++) if ($i != 10001) exit 1
+					}
+					$1 == "Groups:" {
+						groups_seen=1
+						for (i=2; i<=NF; i++) if ($i == 0) exit 1
+					}
+					$1 ~ /^Cap(Inh|Prm|Eff|Bnd|Amb):$/ {
+						capabilities_seen++
+						if ($2 != "0000000000000000") exit 1
+					}
+					$1 == "NoNewPrivs:" {
+						no_new_privs_seen=1
+						if ($2 != 1) exit 1
+					}
+					END {
+						if (!uid_seen || !gid_seen || !groups_seen || capabilities_seen != 5 || !no_new_privs_seen) exit 1
+						print "secure"
+					}' "$status"`,
+				"sh", strconv.Itoa(check.pid), check.name, expectedLibraryPath,
+			)
+			if err != nil {
+				return fmt.Errorf("inspect %s process %d: %w", check.name, check.pid, err)
+			}
+			if securityState != "secure" {
+				return fmt.Errorf("%s process %d security state is %q", check.name, check.pid, securityState)
+			}
+		}
+		return nil
+	})
 }
 
 func (s *scenarioState) stopCandidate() error {
@@ -259,6 +943,9 @@ func (s *scenarioState) startVirtualClient() error {
 		"run", "--detach",
 		"--name", name,
 		"--network", s.networkName,
+		"--user", "10001:10001",
+		"--cap-drop", "ALL",
+		"--security-opt", "no-new-privileges:true",
 		"--entrypoint", "/tmp/bedrock-client",
 		"--volume", s.suite.clientBinary+":/tmp/bedrock-client:ro",
 		s.suite.image,

--- a/acceptance/realimage/features/upgrade.feature
+++ b/acceptance/realimage/features/upgrade.feature
@@ -1,0 +1,74 @@
+@real-image @upgrade
+Feature: Upgrade a legacy root-owned Bedrock world
+  As a Montainer release maintainer
+  I want pre-v3 named volumes to migrate without losing their world
+  So that an ownership change cannot make an existing server unusable
+
+  Scenario: A root-owned world remains playable and backup-safe after upgrade
+    Given the candidate Montainer image is available
+    And S3-compatible MinIO storage is available
+    And a genuine root-owned legacy world exists on named volumes
+    When I start the candidate with the packaged Bedrock server
+    Then the management API eventually becomes healthy
+    And the packaged Bedrock server eventually reports running
+    And a RakNet client can eventually discover the Bedrock server
+    And the legacy scoreboard state is preserved
+    And the upgraded persistence data belongs to UID and GID 10001
+    And Montainer PID 1 and Bedrock run as UID 10001
+    When the virtual Bedrock player joins
+    And I send the real server command "tp MontainerCI 12000 100 -12000"
+    Then the virtual Bedrock player receives the teleport
+    And the candidate reports no filesystem permission errors
+
+    When I request 4 backups concurrently
+    Then exactly one backup succeeds and the others conflict
+    And the uploaded backup is a valid Montainer archive
+    And the uploaded backup retains the legacy world database and canary
+    And the process generation increases by 1
+    And a RakNet client can eventually discover the Bedrock server
+    And the legacy scoreboard state is preserved
+    And Montainer PID 1 and Bedrock run as UID 10001
+    And the candidate reports no filesystem permission errors
+    When I restore the uploaded backup into fresh named volumes
+    Then the management API eventually becomes healthy
+    And the packaged Bedrock server eventually reports running
+    And a RakNet client can eventually discover the Bedrock server
+    And the legacy scoreboard state is preserved
+    And the upgraded persistence data belongs to UID and GID 10001
+    And Montainer PID 1 and Bedrock run as UID 10001
+    And the candidate reports no filesystem permission errors
+    When I stop the candidate container
+    Then the candidate container exits cleanly
+
+  Scenario: A root-owned custom instance is writable before config restoration
+    Given the candidate Montainer image is available
+    And a root-owned custom pre-v3 Bedrock instance exists
+    When I start the candidate with the packaged Bedrock server
+    Then the management API eventually becomes healthy
+    And the packaged Bedrock server eventually reports running
+    And a RakNet client can eventually discover the Bedrock server
+    And the custom instance and persistence data belong to UID and GID 10001
+    And Montainer PID 1 and Bedrock run as UID 10001
+    And the candidate reports no filesystem permission errors
+
+  Scenario: Explicit non-root execution keeps the image health probe working
+    Given the candidate Montainer image is available
+    And the candidate is configured for explicit non-root execution
+    When I start the candidate with the packaged Bedrock server
+    Then the management API eventually becomes healthy
+    And the packaged Bedrock server eventually reports running
+    And a RakNet client can eventually discover the Bedrock server
+    And the candidate container eventually becomes healthy
+    And Montainer PID 1 and Bedrock run as UID 10001
+    And the candidate reports no filesystem permission errors
+
+  Scenario: A same-device nested mount is never included in ownership migration
+    Given the candidate Montainer image is available
+    And an accessible root-owned nested persistence mount exists
+    When I start the candidate with the packaged Bedrock server
+    Then the management API eventually becomes healthy
+    And the candidate container eventually becomes healthy
+    And the parent data migrates while the nested mount stays root-owned
+    And the candidate reports no filesystem permission errors
+    When I stop the candidate container
+    Then the candidate container exits cleanly

--- a/acceptance/realimage/raknet_test.go
+++ b/acceptance/realimage/raknet_test.go
@@ -35,10 +35,15 @@ func (s *scenarioState) pingBedrockInNetwork() (bedrockAdvertisement, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
+	probeName := s.trackHelperContainer("raknet-probe")
 	output, err := s.docker(
 		ctx,
 		"run", "--rm",
+		"--name", probeName,
 		"--network", s.networkName,
+		"--user", "10001:10001",
+		"--cap-drop", "ALL",
+		"--security-opt", "no-new-privileges:true",
 		"--entrypoint", "/tmp/raknet-probe",
 		"--volume", s.suite.probeBinary+":/tmp/raknet-probe:ro",
 		s.suite.image,

--- a/acceptance/realimage/scenario_test.go
+++ b/acceptance/realimage/scenario_test.go
@@ -42,6 +42,7 @@ type scenarioState struct {
 	configDir   string
 	networkName string
 	containers  []string
+	volumes     []string
 	candidate   string
 	collector   string
 	minio       string
@@ -59,6 +60,10 @@ type scenarioState struct {
 	concurrentResults []requestResult
 	lastBackup        backupResult
 	lastAdvertisement bedrockAdvertisement
+	legacyMounts      []volumeMount
+	legacyScore       int
+	legacyChecks      int
+	explicitNonRoot   bool
 }
 
 func (s *scenarioState) initializeScenario(ctx *godog.ScenarioContext) {
@@ -70,6 +75,10 @@ func (s *scenarioState) initializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the configured OpenTelemetry Collector is unavailable$`, s.configureUnavailableCollector)
 	ctx.Step(`^log export batching is delayed until shutdown$`, s.delayOTelUntilShutdown)
 	ctx.Step(`^S3-compatible MinIO storage is available$`, s.startMinIO)
+	ctx.Step(`^a genuine root-owned legacy world exists on named volumes$`, s.seedRootOwnedLegacyWorld)
+	ctx.Step(`^a root-owned custom pre-v3 Bedrock instance exists$`, s.rootOwnedCustomInstanceExists)
+	ctx.Step(`^an accessible root-owned nested persistence mount exists$`, s.accessibleRootOwnedNestedMountExists)
+	ctx.Step(`^the candidate is configured for explicit non-root execution$`, s.configureExplicitNonRootCandidate)
 	ctx.Step(`^I start the candidate with the packaged Bedrock server$`, s.startCandidate)
 	ctx.Step(`^the management API eventually becomes healthy$`, s.apiEventuallyHealthy)
 	ctx.Step(`^the management API remains healthy$`, s.apiHealthy)
@@ -89,6 +98,15 @@ func (s *scenarioState) initializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I request (\d+) backups concurrently$`, s.requestBackupsConcurrently)
 	ctx.Step(`^exactly one backup succeeds and the others conflict$`, s.oneBackupSucceeds)
 	ctx.Step(`^the uploaded backup is a valid Montainer archive$`, s.uploadedBackupIsValid)
+	ctx.Step(`^the uploaded backup retains the legacy world database and canary$`, s.uploadedBackupRetainsLegacyWorld)
+	ctx.Step(`^I restore the uploaded backup into fresh named volumes$`, s.restoreUploadedBackupIntoFreshNamedVolumes)
+	ctx.Step(`^the legacy scoreboard state is preserved$`, s.legacyScoreboardStateIsPreserved)
+	ctx.Step(`^the upgraded persistence data belongs to UID and GID 10001$`, s.upgradedPersistenceOwnedByMontainer)
+	ctx.Step(`^the custom instance and persistence data belong to UID and GID 10001$`, s.customInstancePersistenceOwnedByMontainer)
+	ctx.Step(`^the parent data migrates while the nested mount stays root-owned$`, s.nestedMountOwnershipIsPreserved)
+	ctx.Step(`^Montainer PID 1 and Bedrock run as UID 10001$`, s.candidateProcessesRunAsMontainer)
+	ctx.Step(`^the candidate container eventually becomes healthy$`, s.candidateContainerEventuallyHealthy)
+	ctx.Step(`^the candidate reports no filesystem permission errors$`, s.candidateHasNoPermissionErrors)
 	ctx.Step(`^I stop the candidate container$`, s.stopCandidate)
 	ctx.Step(`^the candidate container exits cleanly$`, s.candidateExitedCleanly)
 	ctx.Step(`^the virtual Bedrock player joins$`, s.startVirtualClient)
@@ -129,6 +147,7 @@ func (s *scenarioState) prepare() error {
 	s.configDir = filepath.Join(tmpDir, "configs")
 	s.networkName = "montainer-real-" + suffix
 	s.containers = nil
+	s.volumes = nil
 	s.candidate = ""
 	s.collector = ""
 	s.minio = ""
@@ -143,6 +162,10 @@ func (s *scenarioState) prepare() error {
 	s.concurrentResults = nil
 	s.lastBackup = backupResult{}
 	s.lastAdvertisement = bedrockAdvertisement{}
+	s.legacyMounts = nil
+	s.legacyScore = 4242
+	s.legacyChecks = 0
+	s.explicitNonRoot = false
 	s.env = map[string]string{
 		"INSTANCE_NAME":                   instanceName,
 		"BEDROCK_AUTO_START":              "true",
@@ -215,6 +238,12 @@ func (s *scenarioState) cleanup() error {
 	for index := len(s.containers) - 1; index >= 0; index-- {
 		if _, err := s.docker(ctx, "rm", "--force", "--volumes", s.containers[index]); err != nil &&
 			!strings.Contains(err.Error(), "No such container") && cleanupErr == nil {
+			cleanupErr = err
+		}
+	}
+	for index := len(s.volumes) - 1; index >= 0; index-- {
+		if _, err := s.docker(ctx, "volume", "rm", "--force", s.volumes[index]); err != nil &&
+			!strings.Contains(err.Error(), "No such volume") && cleanupErr == nil {
 			cleanupErr = err
 		}
 	}

--- a/acceptance/realimage/steps_test.go
+++ b/acceptance/realimage/steps_test.go
@@ -19,6 +19,7 @@ import (
 type statusResponse struct {
 	Running    bool   `json:"is_running"`
 	State      string `json:"state"`
+	PID        int    `json:"pid"`
 	Generation uint64 `json:"generation"`
 }
 
@@ -93,6 +94,53 @@ func (s *scenarioState) logsEventuallyContain(expected string) error {
 		}
 		return nil
 	})
+}
+
+func (s *scenarioState) legacyScoreboardStateIsPreserved() error {
+	expected := s.legacyScore
+	testCommand := fmt.Sprintf(
+		"scoreboard players test %s %s %d %d",
+		legacyPlayerName,
+		legacyObjectiveName,
+		expected,
+		expected,
+	)
+	if err := s.sendCommand(testCommand); err != nil {
+		return fmt.Errorf("query legacy scoreboard state: %w", err)
+	}
+	if err := s.logsEventuallyContain(legacyScoreSentence(expected, expected)); err != nil {
+		return err
+	}
+
+	// Before backup, advance the durable state and confirm the command queue has
+	// applied it. The post-backup assertion then searches for a new exact result,
+	// so an old log line cannot make a failed restart look successful.
+	if s.legacyChecks == 0 {
+		next := expected + 1
+		if err := s.sendCommand(fmt.Sprintf(
+			"scoreboard players set %s %s %d",
+			legacyPlayerName,
+			legacyObjectiveName,
+			next,
+		)); err != nil {
+			return fmt.Errorf("advance legacy scoreboard state: %w", err)
+		}
+		if err := s.sendCommand(fmt.Sprintf(
+			"scoreboard players test %s %s %d %d",
+			legacyPlayerName,
+			legacyObjectiveName,
+			next,
+			next+1,
+		)); err != nil {
+			return fmt.Errorf("confirm advanced legacy scoreboard state: %w", err)
+		}
+		if err := s.logsEventuallyContain(legacyScoreSentence(next, next+1)); err != nil {
+			return err
+		}
+		s.legacyScore = next
+	}
+	s.legacyChecks++
+	return nil
 }
 
 func (s *scenarioState) requestStopsConcurrently(count int) error {
@@ -239,29 +287,9 @@ func (s *scenarioState) oneBackupSucceeds() error {
 }
 
 func (s *scenarioState) uploadedBackupIsValid() error {
-	if s.minioClient == nil {
-		return fmt.Errorf("MinIO client is not configured")
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	response, err := s.minioClient.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(s.minioBucket),
-		Key:    aws.String(s.lastBackup.Key),
-	})
+	reader, err := s.downloadedBackupZIP()
 	if err != nil {
-		return fmt.Errorf("download backup %q: %w", s.lastBackup.Key, err)
-	}
-	defer response.Body.Close()
-	archive, err := io.ReadAll(io.LimitReader(response.Body, 512<<20))
-	if err != nil {
-		return fmt.Errorf("read backup %q: %w", s.lastBackup.Key, err)
-	}
-	if int64(len(archive)) != s.lastBackup.Size {
-		return fmt.Errorf("downloaded archive size is %d, API reported %d", len(archive), s.lastBackup.Size)
-	}
-	reader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
-	if err != nil {
-		return fmt.Errorf("open backup ZIP: %w", err)
+		return err
 	}
 	names := make(map[string]struct{}, len(reader.File))
 	hasWorldData := false
@@ -297,6 +325,115 @@ func (s *scenarioState) uploadedBackupIsValid() error {
 	}
 	if !hasWorldData || !hasLevelDatabase {
 		return fmt.Errorf("backup ZIP does not contain generated world and LevelDB data")
+	}
+	return nil
+}
+
+func (s *scenarioState) uploadedBackupRetainsLegacyWorld() error {
+	reader, err := s.downloadedBackupZIP()
+	if err != nil {
+		return err
+	}
+	worldPrefix := "worlds/" + legacyWorldName + "/"
+	canaryEntry := worldPrefix + legacyCanaryName
+	hasLevelData := false
+	hasLevelDatabase := false
+	hasCanary := false
+	for _, file := range reader.File {
+		switch {
+		case file.Name == worldPrefix+"level.dat" && !file.FileInfo().IsDir():
+			hasLevelData = true
+		case strings.HasPrefix(file.Name, worldPrefix+"db/") && !file.FileInfo().IsDir() && file.UncompressedSize64 > 0:
+			hasLevelDatabase = true
+		case file.Name == canaryEntry && !file.FileInfo().IsDir():
+			stream, openErr := file.Open()
+			if openErr != nil {
+				return fmt.Errorf("open legacy canary from backup: %w", openErr)
+			}
+			contents, readErr := io.ReadAll(io.LimitReader(stream, 4<<10))
+			closeErr := stream.Close()
+			if readErr != nil {
+				return fmt.Errorf("read legacy canary from backup: %w", readErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("close legacy canary from backup: %w", closeErr)
+			}
+			if string(contents) != legacyCanaryContents {
+				return fmt.Errorf("legacy canary contents are %q, want %q", contents, legacyCanaryContents)
+			}
+			hasCanary = true
+		}
+	}
+	if !hasLevelData || !hasLevelDatabase || !hasCanary {
+		return fmt.Errorf(
+			"backup retained legacy world level.dat=%t LevelDB=%t canary=%t",
+			hasLevelData,
+			hasLevelDatabase,
+			hasCanary,
+		)
+	}
+	return nil
+}
+
+func (s *scenarioState) downloadedBackupZIP() (*zip.Reader, error) {
+	archive, err := s.downloadedBackupBytes()
+	if err != nil {
+		return nil, err
+	}
+	reader, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return nil, fmt.Errorf("open backup ZIP: %w", err)
+	}
+	return reader, nil
+}
+
+func (s *scenarioState) downloadedBackupBytes() ([]byte, error) {
+	if s.minioClient == nil {
+		return nil, fmt.Errorf("MinIO client is not configured")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	response, err := s.minioClient.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.minioBucket),
+		Key:    aws.String(s.lastBackup.Key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("download backup %q: %w", s.lastBackup.Key, err)
+	}
+	defer response.Body.Close()
+	archive, err := io.ReadAll(io.LimitReader(response.Body, 512<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read backup %q: %w", s.lastBackup.Key, err)
+	}
+	if int64(len(archive)) != s.lastBackup.Size {
+		return nil, fmt.Errorf("downloaded archive size is %d, API reported %d", len(archive), s.lastBackup.Size)
+	}
+	return archive, nil
+}
+
+func (s *scenarioState) candidateHasNoPermissionErrors() error {
+	if s.candidate == "" {
+		return fmt.Errorf("candidate container is not running")
+	}
+	apiLogs, err := s.currentLogs()
+	if err != nil {
+		return err
+	}
+	containerLogs, err := s.containerLogs(s.candidate)
+	if err != nil {
+		return err
+	}
+	combined := strings.ToLower(apiLogs + "\n" + containerLogs)
+	for _, forbidden := range []string{
+		"permission denied",
+		"operation not permitted",
+		"read-only file system",
+		"failed to open leveldb",
+		"dbstorage chain is invalid",
+	} {
+		if strings.Contains(combined, forbidden) {
+			return fmt.Errorf("candidate logs contain filesystem failure %q", forbidden)
+		}
 	}
 	return nil
 }

--- a/examples/docker/docker-compose.yaml
+++ b/examples/docker/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
       minio-init:
         condition: service_completed_successfully
     stop_grace_period: 90s # Safe for default lifecycle timeouts; increase when customizing them
+    security_opt:
+      - no-new-privileges:true
     restart: unless-stopped
 
   minio:

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,397 @@
+#!/bin/sh
+set -eu
+
+target_uid=10001
+target_gid=10001
+running_pid=
+scratch_dir=
+export LC_ALL=C
+
+cleanup() {
+    if [ -n "$scratch_dir" ]; then
+        rm -rf -- "$scratch_dir"
+        scratch_dir=
+    fi
+}
+
+fatal() {
+    printf 'montainer-entrypoint: %s\n' "$*" >&2
+    cleanup
+    exit 1
+}
+
+validate_nonroot_identity() {
+    current_uid=$(id -u)
+    current_gid=$(id -g)
+    if [ "$current_uid" -ne "$target_uid" ] || [ "$current_gid" -ne "$target_gid" ]; then
+        fatal "explicit non-root mode requires UID/GID ${target_uid}:${target_gid}"
+    fi
+    if ! awk '
+        $1 == "Groups:" {
+            seen=1
+            for (i=2; i<=NF; i++) if ($i == 0) exit 1
+        }
+        END { if (!seen) exit 1 }
+    ' /proc/self/status; then
+        fatal 'explicit non-root mode must not include supplementary group 0'
+    fi
+    if ! awk '
+        $1 ~ /^Cap(Inh|Prm|Eff|Bnd|Amb):$/ {
+            seen++
+            if ($2 != "0000000000000000") exit 1
+        }
+        END { if (seen != 5) exit 1 }
+    ' /proc/self/status; then
+        fatal 'explicit non-root mode requires the OCI runtime to drop all capabilities (Docker: --cap-drop=ALL; Kubernetes: capabilities.drop: [ALL])'
+    fi
+}
+
+# Docker starts this image as root so legacy volumes can be repaired. Normal
+# application and health-check execution always pass through this boundary.
+# An operator-selected non-root identity cannot clear its own capability
+# bounding set, so require the OCI runtime to have dropped it already.
+exec_hardened() {
+    current_uid=$(id -u)
+    if [ "$current_uid" -eq 0 ]; then
+        exec setpriv \
+            --reuid="$target_uid" \
+            --regid="$target_gid" \
+            --clear-groups \
+            --bounding-set=-all \
+            --inh-caps=-all \
+            --ambient-caps=-all \
+            --no-new-privs \
+            "$@"
+    fi
+
+    validate_nonroot_identity
+    exec setpriv \
+        --inh-caps=-all \
+        --ambient-caps=-all \
+        --no-new-privs \
+        "$@"
+}
+
+if [ "${1:-}" = __healthcheck ]; then
+    [ "$#" -eq 1 ] || fatal '__healthcheck does not accept arguments'
+    exec_hardened curl \
+        --fail \
+        --silent \
+        --show-error \
+        --connect-timeout 2 \
+        --max-time 4 \
+        --output /dev/null \
+        http://127.0.0.1:8000/healthz
+fi
+
+terminate() {
+    signal_name=$1
+    exit_code=$2
+    trap - HUP INT TERM
+    if [ -n "$running_pid" ]; then
+        kill "-$signal_name" "-$running_pid" 2>/dev/null \
+            || kill "-$signal_name" "$running_pid" 2>/dev/null \
+            || true
+        wait "$running_pid" 2>/dev/null || true
+        running_pid=
+    fi
+    cleanup
+    exit "$exit_code"
+}
+
+trap 'terminate HUP 129' HUP
+trap 'terminate INT 130' INT
+trap 'terminate TERM 143' TERM
+
+# Run longer filesystem operations in their own process group. While this shell
+# is PID 1, its signal traps can then terminate and reap the entire operation
+# instead of leaving Docker to SIGKILL a partially migrated scan.
+run_guarded() {
+    setsid "$@" &
+    running_pid=$!
+    if wait "$running_pid"; then
+        guarded_status=0
+    else
+        guarded_status=$?
+    fi
+    running_pid=
+    return "$guarded_status"
+}
+
+run_for_identity() {
+    run_identity=$1
+    shift
+    if [ "$run_identity" = target ]; then
+        run_guarded setpriv \
+            --reuid="$target_uid" \
+            --regid="$target_gid" \
+            --clear-groups \
+            --bounding-set=-all \
+            --inh-caps=-all \
+            --ambient-caps=-all \
+            --no-new-privs \
+            "$@"
+        return
+    fi
+    run_guarded "$@"
+}
+
+resolve_data_path() {
+    raw_path=$1
+    [ -n "$raw_path" ] || fatal 'persistent data paths must not be empty'
+    case "$raw_path" in
+        *[[:cntrl:]]*) fatal 'persistent data paths must not contain control characters' ;;
+    esac
+    case "$raw_path" in
+        /*) candidate_path=$raw_path ;;
+        ./*) candidate_path="/app/${raw_path#./}" ;;
+        *) candidate_path="/app/$raw_path" ;;
+    esac
+    [ ! -L "$candidate_path" ] || fatal "refusing symlinked data directory ${candidate_path}"
+    lexical_path=$(realpath -m -s -- "$candidate_path") \
+        || fatal "could not normalize persistent data path ${candidate_path}"
+    resolved_path=$(realpath -m -- "$candidate_path") \
+        || fatal "could not resolve persistent data path ${candidate_path}"
+    [ "$resolved_path" = "$lexical_path" ] \
+        || fatal "refusing data directory with a symbolic-link component ${candidate_path}"
+    [ "$resolved_path" != / ] || fatal 'refusing to use the filesystem root as a persistent data directory'
+    printf '%s\n' "$resolved_path"
+}
+
+validate_data_root() {
+    root_label=$1
+    root_path=$2
+    case "$root_path" in
+        /app | /app/dist | /app/dist/* | /app/montainer | \
+        /bin | /bin/* | /boot | /boot/* | /dev | /dev/* | /etc | /etc/* | \
+        /home | /lib | /lib/* | /lib64 | /lib64/* | /opt | /proc | /proc/* | \
+        /root | /root/* | /run | /run/* | /sbin | /sbin/* | /sys | /sys/* | \
+        /tmp | /usr | /usr/* | /var | /var/cache | /var/lib | /var/log)
+            fatal "${root_label} resolves to protected path ${root_path}; use a dedicated data directory"
+            ;;
+    esac
+}
+
+reject_overlapping_roots() {
+    left_label=$1
+    left_path=$2
+    right_label=$3
+    right_path=$4
+    case "$left_path" in
+        "$right_path" | "$right_path"/*)
+            fatal "${left_label} ${left_path} overlaps ${right_label} ${right_path}; configured data roots must be disjoint"
+            ;;
+    esac
+    case "$right_path" in
+        "$left_path"/*)
+            fatal "${left_label} ${left_path} overlaps ${right_label} ${right_path}; configured data roots must be disjoint"
+            ;;
+    esac
+}
+
+ensure_directory() {
+    ensure_path=$1
+    [ ! -L "$ensure_path" ] || fatal "refusing symlinked data directory ${ensure_path}"
+    mkdir -p -- "$ensure_path" || fatal "could not create persistent data directory ${ensure_path}"
+    [ -d "$ensure_path" ] && [ ! -L "$ensure_path" ] \
+        || fatal "persistent data path ${ensure_path} is not a directory"
+}
+
+escape_find_pattern() {
+    printf '%s\n' "$1" | sed 's/[][\\*?]/\\&/g'
+}
+
+# Mutating scans prune every nested mount reported by the kernel. -xdev alone
+# is insufficient because Docker volumes and bind mounts can share a device ID.
+migrate_legacy_entries() {
+    ownership_path=$1
+    mount_targets=$(findmnt -R -l -n -o TARGET --target "$ownership_path") \
+        || fatal "could not inspect mount boundaries below ${ownership_path}"
+
+    set -- "$ownership_path" -xdev -mindepth 1
+    while IFS= read -r nested_mount; do
+        case "$nested_mount" in
+            *\\x[0-9A-Fa-f][0-9A-Fa-f]*)
+                fatal "refusing escaped or control-character mount target below ${ownership_path}"
+                ;;
+        esac
+        case "$nested_mount" in
+            "$ownership_path") ;;
+            "$ownership_path"/*)
+                nested_pattern=$(escape_find_pattern "$nested_mount")
+                set -- "$@" -path "$nested_pattern" -prune -o
+                ;;
+        esac
+    done <<EOF
+$mount_targets
+EOF
+    # Do not chown multiply linked non-directories: a bind-mounted hardlink can
+    # share an inode with a file outside the configured data root. If such an
+    # entry is not already accessible, the recursive preflight fails safely.
+    set -- "$@" \
+        \( -type d -o \( \( -type f -o -type l \) -links 1 \) \) \
+        \( -uid 0 -o -gid 0 \) \
+        -exec chown --no-dereference "${target_uid}:${target_gid}" {} +
+    run_guarded find "$@"
+}
+
+has_directory_access() {
+    access_identity=$1
+    access_path=$2
+    access_mode=$3
+
+    case "$access_mode" in
+        read)
+            run_for_identity "$access_identity" sh -c '[ -r "$1" ] && [ -x "$1" ]' sh "$access_path" \
+                || return 1
+            set -- "$access_path" \
+                \( -type d \( ! -readable -o ! -executable \) \
+                -o -type f ! -readable \
+                -o ! \( -type d -o -type f -o -type l \) \) \
+                -print -quit
+            ;;
+        instance)
+            run_for_identity "$access_identity" sh -c '[ -r "$1" ] && [ -w "$1" ] && [ -x "$1" ]' sh "$access_path" \
+                || return 1
+            instance_resources=$(escape_find_pattern "${access_path%/}/resource_packs")
+            set -- "$access_path" \
+                \( -type d \( ! -readable -o ! -writable -o ! -executable \) \
+                -o -type f \( ! -readable -o ! -writable \) \
+                -o \( -type l ! -path "${instance_resources}/*" \) \
+                -o ! \( -type d -o -type f -o -type l \) \) \
+                -print -quit
+            ;;
+        write)
+            run_for_identity "$access_identity" sh -c '[ -r "$1" ] && [ -w "$1" ] && [ -x "$1" ]' sh "$access_path" \
+                || return 1
+            set -- "$access_path" \
+                \( -type d \( ! -readable -o ! -writable -o ! -executable \) \
+                -o -type f \( ! -readable -o ! -writable \) \
+                -o ! \( -type d -o -type f \) \) \
+                -print -quit
+            ;;
+        *) fatal "unsupported data access mode ${access_mode}" ;;
+    esac
+
+    : > "$scratch_dir/access-report"
+    : > "$scratch_dir/access-errors"
+    if ! run_for_identity "$access_identity" find "$@" \
+        > "$scratch_dir/access-report" 2> "$scratch_dir/access-errors"; then
+        return 1
+    fi
+    [ ! -s "$scratch_dir/access-report" ] && [ ! -s "$scratch_dir/access-errors" ]
+}
+
+verify_directory_access() {
+    verify_identity=$1
+    verify_path=$2
+    verify_mode=$3
+    if ! has_directory_access "$verify_identity" "$verify_path" "$verify_mode"; then
+        if [ -s "$scratch_dir/access-report" ]; then
+            inaccessible_path=$(sed -n '1p' "$scratch_dir/access-report")
+            printf 'montainer-entrypoint: inaccessible path: %s\n' "$inaccessible_path" >&2
+        elif [ -s "$scratch_dir/access-errors" ]; then
+            sed -n '1p' "$scratch_dir/access-errors" >&2
+        fi
+        fatal "${verify_path} does not provide ${verify_mode} access to the runtime identity; stop the server, back up the mount, repair its ownership or ACL, and retry"
+    fi
+}
+
+migrate_directory() {
+    migrate_path=$1
+    migrate_mode=$2
+    ensure_directory "$migrate_path"
+
+    printf 'montainer-entrypoint: checking legacy ownership under %s\n' "$migrate_path"
+    migration_failed=false
+    if ! run_guarded chown --no-dereference "${target_uid}:${target_gid}" "$migrate_path"; then
+        migration_failed=true
+    fi
+    if ! migrate_legacy_entries "$migrate_path"; then
+        migration_failed=true
+    fi
+
+    # Root-squashed or ACL-managed storage can deny chown while already
+    # granting the target identity everything it needs. Continue only after a
+    # complete read/write traversal proves that it is safe.
+    if [ "$migration_failed" = true ] && has_directory_access target "$migrate_path" "$migrate_mode"; then
+        printf 'montainer-entrypoint: %s is already accessible; denied ownership changes were ignored\n' "$migrate_path"
+        return
+    fi
+    verify_directory_access target "$migrate_path" "$migrate_mode"
+}
+
+case "${MONTAINER_AUTO_CHOWN:-true}" in
+    true | false) ;;
+    *) fatal 'MONTAINER_AUTO_CHOWN must be true or false' ;;
+esac
+
+# Reject a wrong or insufficiently confined explicit identity before it can
+# create or otherwise mutate anything in configured storage.
+if [ "$(id -u)" -ne 0 ]; then
+    validate_nonroot_identity
+fi
+
+scratch_dir=$(mktemp -d /tmp/montainer-entrypoint.XXXXXX) \
+    || fatal 'could not create entrypoint scratch directory'
+
+instance_path=$(resolve_data_path "${INSTANCE_DIR:-/app/instance}")
+worlds_path=$(resolve_data_path "${instance_path%/}/worlds")
+configs_path=$(resolve_data_path "${CONFIG_DIR:-/app/configs}")
+resources_path=$(resolve_data_path "${RESOURCE_PACKS_DIR:-/app/resource_packs}")
+logs_path=$(resolve_data_path "${LOG_DIR:-/app/logs}")
+
+validate_data_root INSTANCE_DIR "$instance_path"
+validate_data_root CONFIG_DIR "$configs_path"
+validate_data_root RESOURCE_PACKS_DIR "$resources_path"
+validate_data_root LOG_DIR "$logs_path"
+reject_overlapping_roots INSTANCE_DIR "$instance_path" CONFIG_DIR "$configs_path"
+reject_overlapping_roots INSTANCE_DIR "$instance_path" RESOURCE_PACKS_DIR "$resources_path"
+reject_overlapping_roots INSTANCE_DIR "$instance_path" LOG_DIR "$logs_path"
+reject_overlapping_roots CONFIG_DIR "$configs_path" RESOURCE_PACKS_DIR "$resources_path"
+reject_overlapping_roots CONFIG_DIR "$configs_path" LOG_DIR "$logs_path"
+reject_overlapping_roots RESOURCE_PACKS_DIR "$resources_path" LOG_DIR "$logs_path"
+
+if [ "$(id -u)" -eq 0 ]; then
+    if [ "${MONTAINER_AUTO_CHOWN:-true}" = true ]; then
+        migrate_directory "$worlds_path" write
+        migrate_directory "$configs_path" write
+        migrate_directory "$resources_path" read
+        migrate_directory "$logs_path" write
+        migrate_directory "$instance_path" instance
+    else
+        ensure_directory "$worlds_path"
+        ensure_directory "$configs_path"
+        ensure_directory "$resources_path"
+        ensure_directory "$logs_path"
+        ensure_directory "$instance_path"
+        verify_directory_access target "$worlds_path" write
+        verify_directory_access target "$configs_path" write
+        verify_directory_access target "$resources_path" read
+        verify_directory_access target "$logs_path" write
+        verify_directory_access target "$instance_path" instance
+    fi
+
+    cleanup
+    trap - HUP INT TERM
+    export HOME=/home/montainer USER=montainer LOGNAME=montainer
+    exec_hardened env LD_LIBRARY_PATH="$instance_path" /app/montainer "$@"
+fi
+
+# An explicit Docker/Kubernetes user cannot migrate ownership. Validate every
+# configured root as that operator-selected identity before Bedrock can touch
+# LevelDB, then preserve the selected identity for the application process.
+ensure_directory "$worlds_path"
+ensure_directory "$configs_path"
+ensure_directory "$resources_path"
+ensure_directory "$logs_path"
+ensure_directory "$instance_path"
+verify_directory_access current "$worlds_path" write
+verify_directory_access current "$configs_path" write
+verify_directory_access current "$resources_path" read
+verify_directory_access current "$logs_path" write
+verify_directory_access current "$instance_path" instance
+cleanup
+trap - HUP INT TERM
+export HOME=/home/montainer USER=montainer LOGNAME=montainer
+exec_hardened env LD_LIBRARY_PATH="$instance_path" /app/montainer "$@"


### PR DESCRIPTION
## What changed

- Repair legacy root-owned instance, world, config, resource-pack, and log data before startup.
- Validate configured roots, symlinks, hardlinks, nested mounts, ownership, and access before Bedrock can open LevelDB.
- Drop to UID/GID 10001 with no capabilities and `no_new_privs` for Montainer, Bedrock, and health checks.
- Preserve explicitly non-root Docker/Kubernetes operation for already-accessible storage.
- Add the stable-only legacy upgrade acceptance shard and make it a release gate.

## Why

Montainer v3 changed the runtime identity to UID/GID 10001. Volumes created by pre-v3 images can remain root-owned, causing LevelDB `Permission denied (13)` and a misleading secondary port error. The world data itself is not corrupt.

This addresses the upgrade failure reported in #30.

## Acceptance coverage

The digest-pinned pre-v3 image creates a real root-owned Bedrock world and scoreboard state. The candidate must:

- load and preserve that same state;
- accept a virtual player and teleport movement;
- complete concurrent S3 backup;
- restore the downloaded archive into fresh volumes and load the same state;
- migrate custom instance roots safely;
- preserve nested-mount ownership boundaries; and
- support the hardened explicitly non-root profile.

## Operator impact

Normal Docker/Compose users can update in place while reusing their existing volumes. A stopped raw snapshot remains recommended. Do not delete volumes or run LevelDB repair. Entrypoint overrides and storage that rejects ownership changes require the documented manual path.

## Verification

- Upgrade acceptance: 4 scenarios, 60/60 steps
- Real-image smoke: 1 scenario, 8/8 steps
- Go vet and race tests
- Frontend lint, 16/16 tests, and production build
- Shell syntax, `actionlint`, diff checks, and image-tag contract validation
