### PR TITLE
fix: bump bedrockclient probe to gophertunnel protocol 2168 (1.26.40)

### DIFF
--- a/test/fixtures/bedrockclient/go.mod
+++ b/test/fixtures/bedrockclient/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/sandertv/go-raknet v1.14.3-0.20250305181847-6af3e95113d6
-	github.com/sandertv/gophertunnel v1.57.1
+	github.com/sandertv/gophertunnel v1.57.2-0.20260805193201-58dd5f9f9fef
 )
 
 require (

--- a/test/fixtures/bedrockclient/go.sum
+++ b/test/fixtures/bedrockclient/go.sum
@@ -58,8 +58,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sandertv/go-raknet v1.14.3-0.20250305181847-6af3e95113d6 h1:ZfK7NCzIDE+dzp5x6NIO4JDLsjsOxi762CNR1Obds2Q=
 github.com/sandertv/go-raknet v1.14.3-0.20250305181847-6af3e95113d6/go.mod h1:/yysjwfCXm2+2OY8mBazLzcxJ3irnylKCyG3FLgUPVU=
-github.com/sandertv/gophertunnel v1.57.1 h1:P14qngVxDCnSedLvGJtkLrzDOVBQEL1fFliBrT3E9Mc=
-github.com/sandertv/gophertunnel v1.57.1/go.mod h1:Frjuk3g1EEGRYjzyrEMS4j/hDvTcez2STfuRHkRPlNU=
+github.com/sandertv/gophertunnel v1.57.2-0.20260805193201-58dd5f9f9fef h1:po9NwQQEgnvprsAj8zi5tqSYR6iz2RQL9o9e5o6xV6Q=
+github.com/sandertv/gophertunnel v1.57.2-0.20260805193201-58dd5f9f9fef/go.mod h1:Frjuk3g1EEGRYjzyrEMS4j/hDvTcez2STfuRHkRPlNU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=

--- a/test/fixtures/bedrockclient/main.go
+++ b/test/fixtures/bedrockclient/main.go
@@ -126,11 +126,12 @@ func main() {
 			math.Abs(float64(movement.Position[2])-expectedPosition[2]) > *positionTolerance) {
 			continue
 		}
+		teleportData, _ := movement.TeleportData.Value()
 		fmt.Printf(
 			"teleported runtime_id=%d position=%.2f,%.2f,%.2f cause=%d tick=%d\n",
 			movement.EntityRuntimeID,
 			movement.Position[0], movement.Position[1], movement.Position[2],
-			movement.TeleportCause,
+			teleportData.TeleportCause,
 			movement.Tick,
 		)
 		return


### PR DESCRIPTION
## Summary
- Mojang's stable Bedrock release jumped to `1.26.40.8`, which advertises protocol `2168`.
- The virtual-player probe (`test/fixtures/bedrockclient`) is a separately pinned Go module used only by the `client` and `upgrade` real-image acceptance suites. It was still pinned to `gophertunnel v1.57.1`, which only implements protocol `1001` (version `1.26.30`).
- Because the probe intentionally fails fast on a protocol mismatch (`acceptance/README.md:69`), it exited before spawning, and every scenario waiting on "the virtual Bedrock player joins" timed out after 2 minutes — see run [31064649908](https://github.com/WasinUddy/Montainer/actions/runs/31064649908), jobs `3 · Accept / stable / client` and `3 · Accept / stable / upgrade`.
- Bumps the fixture's `gophertunnel` dependency to the upstream commit that added `1.26.40`/protocol `2168` support (`minecraft: Update protocol to 1.26.40 (#481)`), and updates the one call site whose `MovePlayer.TeleportCause` field moved into the new optional `TeleportData` struct.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass in `test/fixtures/bedrockclient`.
- [x] Manually dispatched `Montainer CI/CD` (`channel: stable`) on this branch to re-run the real-image acceptance suites, including the previously-failing `client` and `upgrade` shards.

Made with [Cursor](https://cursor.com)